### PR TITLE
update to allow for addition of nobs to lme4 glance

### DIFF
--- a/tests/testthat/_snaps/grouped_generics.md
+++ b/tests/testthat/_snaps/grouped_generics.md
@@ -42,11 +42,11 @@
       list(lmer_df, lm_df)
     Output
       [[1]]
-      # A tibble: 2 x 7
-        sex   sigma  logLik    AIC    BIC REMLcrit df.residual
-        <fct> <dbl>   <dbl>  <dbl>  <dbl>    <dbl>       <int>
-      1 F      415.   -656.  1321.  1331.    1313.          85
-      2 M      355. -20079. 40165. 40189.   40157.        2750
+      # A tibble: 2 x 8
+        sex    nobs sigma  logLik    AIC    BIC REMLcrit df.residual
+        <fct> <int> <dbl>   <dbl>  <dbl>  <dbl>    <dbl>       <int>
+      1 F        89  415.   -656.  1321.  1331.    1313.          85
+      2 M      2754  355. -20079. 40165. 40189.   40157.        2750
       
       [[2]]
       # A tibble: 2 x 13

--- a/tests/testthat/test-grouped_generics.R
+++ b/tests/testthat/test-grouped_generics.R
@@ -65,7 +65,9 @@ test_that(
         formula = interval ~ age
       )
 
-    expect_equal(dim(lmer_df), c(2L, 7L))
+    expect_equal(nrow(lmer_df), 2)
+    ## allow for nobs to be included in later versions of broom.mixed
+    expect_true(ncol(lmer_df) %in% c(7,8)) 
     expect_equal(dim(lm_df)[1], 2L)
 
     expect_snapshot(list(lmer_df, lm_df))

--- a/tests/testthat/test-hybrid_generics.R
+++ b/tests/testthat/test-hybrid_generics.R
@@ -18,9 +18,10 @@ test_that(
       tolerance = 0.001
     )
 
-    expect_equal(
-      dim(glance_performance(lmm_mod, effects = "fixed")), c(1L, 10L)
-    )
+    lmm_glance <- glance_performance(lmm_mod, effects = "fixed")
+    expect_equal(nrow(lmm_glance), 1)
+    ## allow for nobs to be included in later versions of broom.mixed
+    expect_true(ncol(lmm_glance) %in% c(10,11))
 
     # lm
     set.seed(123)


### PR DESCRIPTION
https://github.com/bbolker/broom.mixed/commit/63d4f7f3bc9026797f1f8bbb7390d32690c4a219 breaks `broomExtra` tests by adding another column to the `glance` output.

This PR fixes that incompatibility.

Would it be possible to say to CRAN maintainers that a new version of `broomExtra` will be coming soon ... ?

---

Minor comments (should open these as separate issues ...)

- when loading `broomExtra` I get repeated warnings of the form:

> Warning: [.../broomExtra/R/grouped_generics.R:106] @inherit Unknown inherit type: value


- when testing I get warnings:
> Warning (test-hybrid_generics.R:29:5): hybrid methods works
The `robust` argument is superseded by the `vcov` argument.

(wasn't sure how to fix this in a back-compatible way ...)